### PR TITLE
output reason text on rejection

### DIFF
--- a/lib/Mail/Audit.pm
+++ b/lib/Mail/Audit.pm
@@ -725,6 +725,8 @@ sub reject {
 
   $self->_log(1, "Rejecting with exitcode " . REJECTED . " and reason $_[0]");
 
+  print STDERR @_, "\n";
+
   $self->_exit(REJECTED);
 }
 


### PR DESCRIPTION
This is intended to fix issue #3.

It seems to work for me -- I now see the rejection reason text in a message which was rejected.